### PR TITLE
feat: Implement Get Instruction API

### DIFF
--- a/schema/swagger.yaml
+++ b/schema/swagger.yaml
@@ -249,7 +249,7 @@ paths:
   /instructions/{instructionId}:
     get:
       summary: Get an instruction
-      tags: [Instructions]
+      tags: [Instruction]
       parameters:
         - $ref: '#/components/parameters/instructionId'
       responses:

--- a/src/controllers/instruction.controller.js
+++ b/src/controllers/instruction.controller.js
@@ -29,7 +29,22 @@ async function updateInstruction(req, res) {
 	res.status(200).json(instruction);
 }
 
+/**
+ * Get an instruction by ID
+ * @param {import('express').Request<{ instructionId: string }, any, any> & { user: import('../types/user').UserInfo }} req - The request object
+ * @param {import('express').Response} res - The response object
+ * @returns {Promise<void>}
+ */
+async function getInstruction(req, res) {
+	const instruction = await instructionService.getInstruction(
+		req.params.instructionId,
+		req.user.organisationId,
+	);
+	res.status(200).json(instruction);
+}
+
 module.exports = {
 	createInstruction,
 	updateInstruction,
+	getInstruction,
 };

--- a/src/mappers/instruction.mapper.js
+++ b/src/mappers/instruction.mapper.js
@@ -49,8 +49,28 @@ function toInstructionVersionEntity(instructionEntity, instructionData) {
 	};
 }
 
+/**
+ * @param {import("../types/instruction").InstructionEntity} instruction
+ * @param {import("../types/instruction").InstructionVersionEntity[]} instructionVersions
+ * @returns {import("../types/instruction").InstructionDetails}
+ */
+function toInstructionWithAllVersions(instruction, instructionVersions) {
+	return {
+		instructionId: instruction._id,
+		name: instruction.name,
+		type: instruction.type,
+		versions: instructionVersions.map((version) => ({
+			instructionVersionId: version._id,
+			version: version.version,
+			description: version.description,
+			content: version.content,
+		})),
+	};
+}
+
 module.exports = {
 	toInstructionDetail,
 	toInstructionEntity,
 	toInstructionVersionEntity,
+	toInstructionWithAllVersions,
 };

--- a/src/mappers/instruction.mapper.js
+++ b/src/mappers/instruction.mapper.js
@@ -1,4 +1,5 @@
 /**
+ * Convert instruction entity and instruction version entity to instruction detail
  * @param {import("../types/instruction").InstructionEntity} instruction
  * @param {import("../types/instruction").InstructionVersionEntity} instructionVersion
  * @returns {import("../types/instruction").InstructionDetails}
@@ -8,19 +9,12 @@ function toInstructionDetail(instruction, instructionVersion) {
 		instructionId: instruction._id,
 		name: instruction.name,
 		type: instruction.type,
-		versions: [
-			{
-				instructionVersionId: instructionVersion._id,
-				version: instructionVersion.version,
-				description: instructionVersion.description,
-				content: instructionVersion.content,
-			},
-		],
+		versions: [toInstructionVersionInfo(instructionVersion)],
 	};
 }
 
 /**
- *
+ * Convert instruction creation data to instruction entity
  * @param {import("../types/instruction").CreateInstruction} instructionData
  * @param {string} organisationId
  * @returns {import("../types/instruction").InstructionEntity}
@@ -35,7 +29,7 @@ function toInstructionEntity(instructionData, organisationId) {
 }
 
 /**
- *
+ * Convert instruction creating data and instruction entity to instruction version entity
  * @param {import("../types/instruction").InstructionEntity} instructionEntity
  * @param {import("../types/instruction").CreateInstruction} instructionData
  * @returns {import("../types/instruction").InstructionVersionEntity}
@@ -50,6 +44,7 @@ function toInstructionVersionEntity(instructionEntity, instructionData) {
 }
 
 /**
+ * Convert instruction entity and instruction version entities to instruction details
  * @param {import("../types/instruction").InstructionEntity} instruction
  * @param {import("../types/instruction").InstructionVersionEntity[]} instructionVersions
  * @returns {import("../types/instruction").InstructionDetails}
@@ -59,12 +54,21 @@ function toInstructionWithAllVersions(instruction, instructionVersions) {
 		instructionId: instruction._id,
 		name: instruction.name,
 		type: instruction.type,
-		versions: instructionVersions.map((version) => ({
-			instructionVersionId: version._id,
-			version: version.version,
-			description: version.description,
-			content: version.content,
-		})),
+		versions: instructionVersions.map(toInstructionVersionInfo),
+	};
+}
+
+/**
+ * Convert instruction version entity to instruction version info
+ * @param {import("../types/instruction").InstructionVersionEntity} instructionVersionEntity
+ * @returns {import("../types/instruction").InstructionVersion}
+ */
+function toInstructionVersionInfo(instructionVersionEntity) {
+	return {
+		instructionVersionId: instructionVersionEntity._id,
+		version: instructionVersionEntity.version,
+		description: instructionVersionEntity.description,
+		content: instructionVersionEntity.content,
 	};
 }
 

--- a/src/routes/instruction.routes.js
+++ b/src/routes/instruction.routes.js
@@ -30,4 +30,11 @@ router.put(
 	catchAsync(instructionController.updateInstruction),
 );
 
+router.get(
+	"/:instructionId",
+	auth,
+	role(ROLE.USER),
+	catchAsync(instructionController.getInstruction),
+);
+
 module.exports = router;

--- a/src/services/instruction.service.js
+++ b/src/services/instruction.service.js
@@ -2,7 +2,7 @@ const mongoose = require("mongoose");
 const Instruction = require("../models/instruction.model");
 const InstructionVersion = require("../models/instructionVersion.model");
 const instructionMapper = require("../mappers/instruction.mapper");
-const { ERROR_CODE } = require("../constants/errorCode");
+const ERROR_CODE = require("../constants/errorCode");
 const GenieLabError = require("../utils/GenieLabError");
 
 /**
@@ -127,7 +127,36 @@ async function checkNameExist(name, organisationId, session = null) {
 	}
 }
 
+/**
+ * Get an instruction by ID with all its versions
+ * @param {string} instructionId - The ID of the instruction
+ * @param {string} organisationId - The ID of the organisation
+ * @returns {Promise<import("../types/instruction").InstructionInfo>}
+ */
+async function getInstruction(instructionId, organisationId) {
+	const instruction = await Instruction.findOne({
+		_id: instructionId,
+		organisation_id: organisationId,
+	});
+
+	if (!instruction) {
+		throw new GenieLabError(
+			ERROR_CODE.INSTRUCTION_NOT_FOUND.code,
+			ERROR_CODE.INSTRUCTION_NOT_FOUND.message,
+			[],
+			404,
+		);
+	}
+
+	const versions = await InstructionVersion.find({
+		instruction_id: instructionId,
+	}).sort({ version: -1 });
+
+	return instructionMapper.toInstructionWithAllVersions(instruction, versions);
+}
+
 module.exports = {
 	createInstruction,
 	updateInstruction,
+	getInstruction,
 };

--- a/src/services/instruction.service.js
+++ b/src/services/instruction.service.js
@@ -131,7 +131,7 @@ async function checkNameExist(name, organisationId, session = null) {
  * Get an instruction by ID with all its versions
  * @param {string} instructionId - The ID of the instruction
  * @param {string} organisationId - The ID of the organisation
- * @returns {Promise<import("../types/instruction").InstructionInfo>}
+ * @returns {Promise<import("../types/instruction").InstructionDetails>}
  */
 async function getInstruction(instructionId, organisationId) {
 	const instruction = await Instruction.findOne({

--- a/tests/instruction.test.js
+++ b/tests/instruction.test.js
@@ -179,4 +179,110 @@ describe("Instruction endpoints", () => {
 			expect(res.statusCode).toEqual(400);
 		});
 	});
+
+	describe("GET /api/instructions/:instructionId", () => {
+		let token, instruction;
+
+		beforeEach(async () => {
+			const org = await new Organisation({ name: "Test Org" }).save();
+			const organisationId = org._id.toString();
+
+			const salt = await bcrypt.genSalt(10);
+			const hashedPassword = await bcrypt.hash("password", salt);
+
+			const user = new User({
+				username: "testuser",
+				email: "testuser@test.com",
+				password: hashedPassword,
+				organisation_id: organisationId,
+				role: "user",
+			});
+			await user.save();
+
+			const resLogin = await request(app)
+				.post("/api/auth/login")
+				.send({ email: "testuser@test.com", password: "password" });
+			token = resLogin.body.token;
+
+			const newInstruction = {
+				name: "Test Instruction",
+				content: "This is a test instruction.",
+				type: "personality",
+				description: "This is a test description.",
+			};
+
+			// We need an admin to create the instruction first
+			const adminUser = new User({
+				username: "adminuser",
+				email: "adminuser@test.com",
+				password: hashedPassword,
+				organisation_id: organisationId,
+				role: "admin",
+			});
+			await adminUser.save();
+			const resAdminLogin = await request(app)
+				.post("/api/auth/login")
+				.send({ email: "adminuser@test.com", password: "password" });
+			const adminToken = resAdminLogin.body.token;
+
+			const res = await request(app)
+				.post("/api/instructions")
+				.set("Authorization", `Bearer ${adminToken}`)
+				.send(newInstruction);
+			instruction = res.body;
+
+			// update to create a second version
+			await request(app)
+				.put(`/api/instructions/${instruction.instructionId}`)
+				.set("Authorization", `Bearer ${adminToken}`)
+				.send({ content: "new content" });
+		});
+
+		it("should return the instruction with all its versions", async () => {
+			const res = await request(app)
+				.get(`/api/instructions/${instruction.instructionId}`)
+				.set("Authorization", `Bearer ${token}`);
+
+			expect(res.statusCode).toEqual(200);
+			expect(res.body).toHaveProperty("instructionId");
+			expect(res.body.name).toBe(instruction.name);
+			expect(res.body.versions.length).toBe(2);
+			expect(res.body.versions[0].version).toBe(2);
+			expect(res.body.versions[1].version).toBe(1);
+		});
+
+		it("should return 404 if instruction not found", async () => {
+			const res = await request(app)
+				.get(`/api/instructions/60f6e1b9b5f3c1a9c8b4b6d4`)
+				.set("Authorization", `Bearer ${token}`);
+
+			expect(res.statusCode).toEqual(404);
+		});
+
+		it("should return 404 if user from another org tries to access", async () => {
+			// Create another org and user
+			const anotherOrg = await new Organisation({ name: "Another Org" }).save();
+			const anotherOrganisationId = anotherOrg._id.toString();
+			const salt = await bcrypt.genSalt(10);
+			const hashedPassword = await bcrypt.hash("password", salt);
+			const anotherUser = new User({
+				username: "anotheruser",
+				email: "anotheruser@test.com",
+				password: hashedPassword,
+				organisation_id: anotherOrganisationId,
+				role: "user",
+			});
+			await anotherUser.save();
+			const resAnotherLogin = await request(app)
+				.post("/api/auth/login")
+				.send({ email: "anotheruser@test.com", password: "password" });
+			const anotherToken = resAnotherLogin.body.token;
+
+			const res = await request(app)
+				.get(`/api/instructions/${instruction.instructionId}`)
+				.set("Authorization", `Bearer ${anotherToken}`);
+
+			expect(res.statusCode).toEqual(404);
+		});
+	});
 });


### PR DESCRIPTION
This commit implements a new API endpoint to get an instruction by its ID, including all its versions.

The new endpoint is `GET /api/instructions/:instructionId`. It requires user role.

Changes include:
- Added a new route in `src/routes/instruction.routes.js`.
- Added a new controller function `getInstruction` in `src/controllers/instruction.controller.js`.
- Added a new service function `getInstruction` in `src/services/instruction.service.js`.
- Added a new mapper function `toInstructionWithAllVersions` in `src/mappers/instruction.mapper.js`.
- Added a new test suite for the new endpoint in `tests/instruction.test.js`.
- Fixed a bug in `src/services/instruction.service.js` where `ERROR_CODE` was not imported correctly.