### PR TITLE
feat: Do not update instruction if content and description are the same

### DIFF
--- a/src/services/instruction.service.js
+++ b/src/services/instruction.service.js
@@ -81,7 +81,18 @@ async function updateInstruction(instructionId, organisationId, instructionData)
 				{ sort: { version: -1 }, session },
 			);
 
-			if (instructionData.content) {
+			const isDescriptionSame =
+				!instructionData.description ||
+				latestVersion.description === instructionData.description;
+			const isContentSame =
+				!instructionData.content ||
+				latestVersion.content === instructionData.content;
+
+			if (isDescriptionSame && isContentSame) {
+				return instructionMapper.toInstructionDetail(instruction, latestVersion);
+			}
+
+			if (instructionData.content && !isContentSame) {
 				const newVersion = new InstructionVersion({
 					instruction_id: instructionId,
 					version: latestVersion.version + 1,
@@ -94,7 +105,8 @@ async function updateInstruction(instructionId, organisationId, instructionData)
 				return instructionMapper.toInstructionDetail(instruction, savedVersion);
 			}
 
-			latestVersion.description = instructionData.description;
+			latestVersion.description =
+				instructionData.description || latestVersion.description;
 			const savedVersion = await latestVersion.save({ session });
 			return instructionMapper.toInstructionDetail(instruction, savedVersion);
 		});

--- a/tests/instruction.test.js
+++ b/tests/instruction.test.js
@@ -178,6 +178,32 @@ describe("Instruction endpoints", () => {
 
 			expect(res.statusCode).toEqual(400);
 		});
+
+		it("should not update and return the same version if content and description are the same", async () => {
+			const updatedInstruction = {
+				content: instruction.versions[0].content,
+				description: instruction.versions[0].description,
+			};
+
+			const res = await request(app)
+				.put(`/api/instructions/${instruction.instructionId}`)
+				.set("Authorization", `Bearer ${token}`)
+				.send(updatedInstruction);
+
+			expect(res.statusCode).toEqual(200);
+			expect(res.body.versions[0].version).toBe(1);
+			expect(res.body.versions.length).toBe(1);
+
+			const instructionInDb = await Instruction.findById(
+				instruction.instructionId,
+			);
+			expect(instructionInDb.latestVersion).toBe(1);
+
+			const instructionVersions = await InstructionVersion.find({
+				instruction_id: instruction.instructionId,
+			});
+			expect(instructionVersions.length).toBe(1);
+		});
 	});
 
 	describe("GET /api/instructions/:instructionId", () => {


### PR DESCRIPTION
This commit modifies the `updateInstruction` service method.

The method now checks if the provided `description` and `content` are the same as the latest version of the instruction. If there are no changes, the method returns the existing instruction details without performing any unnecessary database operations.

A new test case has been added to verify this behavior.