### PR TITLE
feat: Implement Get All Instructions endpoint

### DIFF
--- a/schema/swagger.yaml
+++ b/schema/swagger.yaml
@@ -292,7 +292,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/InstructionVersion'
+                $ref: '#/components/schemas/InstructionVersionInfo'
         '400':
           description: Validation error
           content:
@@ -333,7 +333,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/InstructionVersion'
+                $ref: '#/components/schemas/InstructionVersionInfo'
         '400':
           description: Validation error
           content:
@@ -515,12 +515,12 @@ components:
             - versions
           properties:
             versions:
-              $ref: '#/components/schemas/InstructionVersionList'
+              $ref: '#/components/schemas/InstructionVersionInfoList'
     InstructionInfoList:
       type: array
       items:
         $ref: '#/components/schemas/InstructionInfo'
-    InstructionVersion:
+    InstructionVersionInfo:
       type: object
       required:
         - instructionVersionId
@@ -544,10 +544,10 @@ components:
           type: string
           description: Instruction content
           example: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-    InstructionVersionList:
+    InstructionVersionInfoList:
       type: array
       items:
-        $ref: '#/components/schemas/InstructionVersion'
+        $ref: '#/components/schemas/InstructionVersionInfo'
     CreateInstruction: 
       type: object
       required:

--- a/schema/swagger.yaml
+++ b/schema/swagger.yaml
@@ -185,6 +185,8 @@ paths:
     get:
       summary: Get all instructions
       tags: [Instruction]
+      security:
+        - bearerAuth: []
       responses:
         '200':
           description: OK
@@ -290,7 +292,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/InstructionVersionInfo'
+                $ref: '#/components/schemas/InstructionVersion'
         '400':
           description: Validation error
           content:
@@ -331,7 +333,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/InstructionVersionInfo'
+                $ref: '#/components/schemas/InstructionVersion'
         '400':
           description: Validation error
           content:
@@ -518,7 +520,7 @@ components:
       type: array
       items:
         $ref: '#/components/schemas/InstructionInfo'
-    InstructionVersionInfo:
+    InstructionVersion:
       type: object
       required:
         - instructionVersionId
@@ -542,7 +544,7 @@ components:
           type: string
           description: Instruction content
           example: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-    InstructionVersionInfoList:
+    InstructionVersionList:
       type: array
       items:
         $ref: '#/components/schemas/InstructionVersion'

--- a/src/controllers/instruction.controller.js
+++ b/src/controllers/instruction.controller.js
@@ -28,7 +28,21 @@ async function getInstruction(req, res) {
 	res.status(200).json(instruction);
 }
 
+/**
+ * Get all instructions
+ * @param {import('express').Request<any, any, any> & { user: import('../types/user').UserInfo }} req - The request object
+ * @param {import('express').Response} res - The response object
+ * @returns {Promise<void>}
+ * */
+async function getAllInstructions(req, res) {
+	const instructions = await instructionService.getAllInstructions(
+		req.user.organisationId,
+	);
+	res.status(200).json(instructions);
+}
+
 module.exports = {
 	createInstruction,
 	getInstruction,
+	getAllInstructions,
 };

--- a/src/mappers/instruction.mapper.js
+++ b/src/mappers/instruction.mapper.js
@@ -61,7 +61,7 @@ function toInstructionWithAllVersions(instruction, instructionVersions) {
 /**
  * Convert instruction version entity to instruction version info
  * @param {import("../types/instruction").InstructionVersionEntity} instructionVersionEntity
- * @returns {import("../types/instruction").InstructionVersion}
+ * @returns {import("../types/instruction").InstructionVersionInfo}
  */
 function toInstructionVersionInfo(instructionVersionEntity) {
 	return {

--- a/src/mappers/instruction.mapper.js
+++ b/src/mappers/instruction.mapper.js
@@ -72,9 +72,32 @@ function toInstructionVersionInfo(instructionVersionEntity) {
 	};
 }
 
+/**
+ * Convert instruction version entity to instruction info
+ * @param {import("../types/instruction").InstructionEntity} instructionEntity
+ * @returns {import("../types/instruction").InstructionInfo}
+ */
+function toInstructionInfo(instructionEntity) {
+	return {
+		instructionId: instructionEntity._id,
+		name: instructionEntity.name,
+		type: instructionEntity.type,
+	};
+}
+
+/**
+ * Convert instruction entities to instruction info list
+ * @param {import("../types/instruction").InstructionEntity[]} instructionEntities
+ * @returns {import("../types/instruction").InstructionInfoList}
+ * */
+function toInstructionInfoList(instructionEntities) {
+	return instructionEntities.map(toInstructionInfo);
+}
+
 module.exports = {
 	toInstructionDetail,
 	toInstructionEntity,
 	toInstructionVersionEntity,
 	toInstructionWithAllVersions,
+	toInstructionInfoList,
 };

--- a/src/routes/instruction.routes.js
+++ b/src/routes/instruction.routes.js
@@ -27,4 +27,11 @@ router.get(
 	catchAsync(instructionController.getInstruction),
 );
 
+router.get(
+	"/",
+	auth,
+	role(ROLE.USER),
+	catchAsync(instructionController.getAllInstructions),
+);
+
 module.exports = router;

--- a/src/services/instruction.service.js
+++ b/src/services/instruction.service.js
@@ -95,7 +95,20 @@ async function getInstruction(instructionId, organisationId) {
 	return instructionMapper.toInstructionWithAllVersions(instruction, versions);
 }
 
+/**
+ * Get all instructions for an organisation
+ * @param {string} organisationId - The ID of the organisation
+ * @returns {Promise<import("../types/instruction").InstructionInfoList>}
+ */
+async function getAllInstructions(organisationId) {
+	const instructions = await Instruction.find({
+		organisation_id: organisationId,
+	});
+	return instructionMapper.toInstructionInfoList(instructions);
+}
+
 module.exports = {
 	createInstruction,
 	getInstruction,
+	getAllInstructions,
 };

--- a/src/types/instruction.d.ts
+++ b/src/types/instruction.d.ts
@@ -26,5 +26,4 @@ export type InstructionInfo = components["schemas"]["InstructionInfo"];
 export type InstructionInfoList = components["schemas"]["InstructionInfoList"];
 export type InstructionDetails = components["schemas"]["InstructionDetails"];
 export type InstructionVersion = components["schemas"]["InstructionVersion"];
-export type InstructionVersionList =
-	components["schemas"]["InstructionVersionList"];
+export type InstructionVersionList = components["schemas"]["InstructionVersionList"];

--- a/src/types/instruction.d.ts
+++ b/src/types/instruction.d.ts
@@ -25,5 +25,5 @@ export type UpdateInstruction = components["schemas"]["UpdateInstruction"];
 export type InstructionInfo = components["schemas"]["InstructionInfo"];
 export type InstructionInfoList = components["schemas"]["InstructionInfoList"];
 export type InstructionDetails = components["schemas"]["InstructionDetails"];
-export type InstructionVersion = components["schemas"]["InstructionVersion"];
-export type InstructionVersionList = components["schemas"]["InstructionVersionList"];
+export type InstructionVersionInfo = components["schemas"]["InstructionVersionInfo"];
+export type InstructionVersionInfoList = components["schemas"]["InstructionVersionInfoList"];

--- a/src/types/instruction.d.ts
+++ b/src/types/instruction.d.ts
@@ -25,5 +25,7 @@ export type UpdateInstruction = components["schemas"]["UpdateInstruction"];
 export type InstructionInfo = components["schemas"]["InstructionInfo"];
 export type InstructionInfoList = components["schemas"]["InstructionInfoList"];
 export type InstructionDetails = components["schemas"]["InstructionDetails"];
-export type InstructionVersionInfo = components["schemas"]["InstructionVersionInfo"];
-export type InstructionVersionInfoList = components["schemas"]["InstructionVersionInfoList"];
+export type InstructionVersionInfo =
+	components["schemas"]["InstructionVersionInfo"];
+export type InstructionVersionInfoList =
+	components["schemas"]["InstructionVersionInfoList"];

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -4,726 +4,792 @@
  */
 
 export interface paths {
-	"/auth/login": {
-		parameters: {
-			query?: never;
-			header?: never;
-			path?: never;
-			cookie?: never;
-		};
-		get?: never;
-		put?: never;
-		/**
-		 * User login
-		 * @description Authenticate a user and receive a JWT token
-		 */
-		post: {
-			parameters: {
-				query?: never;
-				header?: never;
-				path?: never;
-				cookie?: never;
-			};
-			requestBody: {
-				content: {
-					"application/json": components["schemas"]["UserLogin"];
-				};
-			};
-			responses: {
-				/** @description Successful login */
-				200: {
-					headers: {
-						[name: string]: unknown;
-					};
-					content: {
-						"application/json": components["schemas"]["Token"];
-					};
-				};
-				/** @description Validation error */
-				400: {
-					headers: {
-						[name: string]: unknown;
-					};
-					content: {
-						"application/json": components["schemas"]["Error"];
-					};
-				};
-				/** @description Invalid credentials */
-				401: {
-					headers: {
-						[name: string]: unknown;
-					};
-					content: {
-						"application/json": components["schemas"]["Error"];
-					};
-				};
-			};
-		};
-		delete?: never;
-		options?: never;
-		head?: never;
-		patch?: never;
-		trace?: never;
-	};
-	"/users": {
-		parameters: {
-			query?: never;
-			header?: never;
-			path?: never;
-			cookie?: never;
-		};
-		/**
-		 * Get all users
-		 * @description Retrieve a list of all users (root role required)
-		 */
-		get: {
-			parameters: {
-				query?: never;
-				header?: never;
-				path?: never;
-				cookie?: never;
-			};
-			requestBody?: never;
-			responses: {
-				/** @description A list of users */
-				200: {
-					headers: {
-						[name: string]: unknown;
-					};
-					content: {
-						"application/json": components["schemas"]["UserInfo"][];
-					};
-				};
-				/** @description Unauthorized */
-				401: {
-					headers: {
-						[name: string]: unknown;
-					};
-					content: {
-						"application/json": components["schemas"]["Error"];
-					};
-				};
-				/** @description Forbidden - insufficient permissions */
-				403: {
-					headers: {
-						[name: string]: unknown;
-					};
-					content: {
-						"application/json": components["schemas"]["Error"];
-					};
-				};
-			};
-		};
-		put?: never;
-		/**
-		 * Create a new user
-		 * @description Create a new user (root role required)
-		 */
-		post: {
-			parameters: {
-				query?: never;
-				header?: never;
-				path?: never;
-				cookie?: never;
-			};
-			requestBody: {
-				content: {
-					"application/json": components["schemas"]["CreateUser"];
-				};
-			};
-			responses: {
-				/** @description User created successfully */
-				201: {
-					headers: {
-						[name: string]: unknown;
-					};
-					content: {
-						"application/json": components["schemas"]["UserInfo"];
-					};
-				};
-				/** @description Validation error */
-				400: {
-					headers: {
-						[name: string]: unknown;
-					};
-					content: {
-						"application/json": components["schemas"]["Error"];
-					};
-				};
-				/** @description Unauthorized */
-				401: {
-					headers: {
-						[name: string]: unknown;
-					};
-					content: {
-						"application/json": components["schemas"]["Error"];
-					};
-				};
-				/** @description Forbidden - insufficient permissions */
-				403: {
-					headers: {
-						[name: string]: unknown;
-					};
-					content: {
-						"application/json": components["schemas"]["Error"];
-					};
-				};
-			};
-		};
-		delete?: never;
-		options?: never;
-		head?: never;
-		patch?: never;
-		trace?: never;
-	};
-	"/users/{userId}": {
-		parameters: {
-			query?: never;
-			header?: never;
-			path?: never;
-			cookie?: never;
-		};
-		/**
-		 * Get a specific user
-		 * @description Retrieve details of a specific user by ID (root role required)
-		 */
-		get: {
-			parameters: {
-				query?: never;
-				header?: never;
-				path: {
-					userId: components["parameters"]["userId"];
-				};
-				cookie?: never;
-			};
-			requestBody?: never;
-			responses: {
-				/** @description User details */
-				200: {
-					headers: {
-						[name: string]: unknown;
-					};
-					content: {
-						"application/json": components["schemas"]["UserInfo"];
-					};
-				};
-				/** @description Unauthorized */
-				401: {
-					headers: {
-						[name: string]: unknown;
-					};
-					content: {
-						"application/json": components["schemas"]["Error"];
-					};
-				};
-				/** @description Forbidden - insufficient permissions */
-				403: {
-					headers: {
-						[name: string]: unknown;
-					};
-					content: {
-						"application/json": components["schemas"]["Error"];
-					};
-				};
-				/** @description User not found */
-				404: {
-					headers: {
-						[name: string]: unknown;
-					};
-					content: {
-						"application/json": components["schemas"]["Error"];
-					};
-				};
-			};
-		};
-		put?: never;
-		post?: never;
-		delete?: never;
-		options?: never;
-		head?: never;
-		patch?: never;
-		trace?: never;
-	};
-	"/organisations": {
-		parameters: {
-			query?: never;
-			header?: never;
-			path?: never;
-			cookie?: never;
-		};
-		get?: never;
-		put?: never;
-		/**
-		 * Create a new organisation
-		 * @description Create a new organisation with a root user
-		 */
-		post: {
-			parameters: {
-				query?: never;
-				header?: never;
-				path?: never;
-				cookie?: never;
-			};
-			requestBody: {
-				content: {
-					"application/json": components["schemas"]["CreateOrganisation"];
-				};
-			};
-			responses: {
-				/** @description Organisation and root user created successfully */
-				201: {
-					headers: {
-						[name: string]: unknown;
-					};
-					content: {
-						"application/json": {
-							organisation?: components["schemas"]["Organisation"];
-							user?: components["schemas"]["UserInfo"];
-						};
-					};
-				};
-				/** @description Validation error */
-				400: {
-					headers: {
-						[name: string]: unknown;
-					};
-					content: {
-						"application/json": components["schemas"]["Error"];
-					};
-				};
-			};
-		};
-		delete?: never;
-		options?: never;
-		head?: never;
-		patch?: never;
-		trace?: never;
-	};
-	"/instructions": {
-		parameters: {
-			query?: never;
-			header?: never;
-			path?: never;
-			cookie?: never;
-		};
-		/** Get all instructions */
-		get: {
-			parameters: {
-				query?: never;
-				header?: never;
-				path?: never;
-				cookie?: never;
-			};
-			requestBody?: never;
-			responses: {
-				/** @description OK */
-				200: {
-					headers: {
-						[name: string]: unknown;
-					};
-					content: {
-						"application/json": components["schemas"]["InstructionInfoList"][];
-					};
-				};
-				/** @description Validation error */
-				400: {
-					headers: {
-						[name: string]: unknown;
-					};
-					content: {
-						"application/json": components["schemas"]["Error"];
-					};
-				};
-				/** @description Unauthorized */
-				401: {
-					headers: {
-						[name: string]: unknown;
-					};
-					content: {
-						"application/json": components["schemas"]["Error"];
-					};
-				};
-				/** @description Forbidden - insufficient permissions */
-				403: {
-					headers: {
-						[name: string]: unknown;
-					};
-					content: {
-						"application/json": components["schemas"]["Error"];
-					};
-				};
-			};
-		};
-		put?: never;
-		/** Create a new instruction */
-		post: {
-			parameters: {
-				query?: never;
-				header?: never;
-				path?: never;
-				cookie?: never;
-			};
-			requestBody: {
-				content: {
-					"application/json": components["schemas"]["CreateInstruction"];
-				};
-			};
-			responses: {
-				/** @description The created instruction */
-				201: {
-					headers: {
-						[name: string]: unknown;
-					};
-					content: {
-						"application/json": components["schemas"]["InstructionDetails"];
-					};
-				};
-				/** @description Validation error */
-				400: {
-					headers: {
-						[name: string]: unknown;
-					};
-					content: {
-						"application/json": components["schemas"]["Error"];
-					};
-				};
-				/** @description Unauthorized */
-				401: {
-					headers: {
-						[name: string]: unknown;
-					};
-					content: {
-						"application/json": components["schemas"]["Error"];
-					};
-				};
-				/** @description Forbidden - insufficient permissions */
-				403: {
-					headers: {
-						[name: string]: unknown;
-					};
-					content: {
-						"application/json": components["schemas"]["Error"];
-					};
-				};
-			};
-		};
-		delete?: never;
-		options?: never;
-		head?: never;
-		patch?: never;
-		trace?: never;
-	};
-	"/instructions/{instructionId}": {
-		parameters: {
-			query?: never;
-			header?: never;
-			path?: never;
-			cookie?: never;
-		};
-		/** Get an instruction */
-		get: {
-			parameters: {
-				query?: never;
-				header?: never;
-				path: {
-					instructionId: components["parameters"]["instructionId"];
-				};
-				cookie?: never;
-			};
-			requestBody?: never;
-			responses: {
-				/** @description Success */
-				200: {
-					headers: {
-						[name: string]: unknown;
-					};
-					content: {
-						"application/json": components["schemas"]["InstructionDetails"];
-					};
-				};
-				/** @description Validation error */
-				400: {
-					headers: {
-						[name: string]: unknown;
-					};
-					content: {
-						"application/json": components["schemas"]["Error"];
-					};
-				};
-				/** @description Unauthorized */
-				401: {
-					headers: {
-						[name: string]: unknown;
-					};
-					content: {
-						"application/json": components["schemas"]["Error"];
-					};
-				};
-				/** @description Forbidden - insufficient permissions */
-				403: {
-					headers: {
-						[name: string]: unknown;
-					};
-					content: {
-						"application/json": components["schemas"]["Error"];
-					};
-				};
-			};
-		};
-		put?: never;
-		/**
-		 * Update an instruction
-		 * @description Update an instruction
-		 */
-		post: {
-			parameters: {
-				query?: never;
-				header?: never;
-				path: {
-					instructionId: components["parameters"]["instructionId"];
-				};
-				cookie?: never;
-			};
-			requestBody: {
-				content: {
-					"application/json": components["schemas"]["UpdateInstruction"];
-				};
-			};
-			responses: {
-				/** @description Success */
-				200: {
-					headers: {
-						[name: string]: unknown;
-					};
-					content: {
-						"application/json": components["schemas"]["InstructionDetails"];
-					};
-				};
-				/** @description Validation error */
-				400: {
-					headers: {
-						[name: string]: unknown;
-					};
-					content: {
-						"application/json": components["schemas"]["Error"];
-					};
-				};
-				/** @description Unauthorized */
-				401: {
-					headers: {
-						[name: string]: unknown;
-					};
-					content: {
-						"application/json": components["schemas"]["Error"];
-					};
-				};
-				/** @description Forbidden - insufficient permissions */
-				403: {
-					headers: {
-						[name: string]: unknown;
-					};
-					content: {
-						"application/json": components["schemas"]["Error"];
-					};
-				};
-			};
-		};
-		delete?: never;
-		options?: never;
-		head?: never;
-		patch?: never;
-		trace?: never;
-	};
+    "/auth/login": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * User login
+         * @description Authenticate a user and receive a JWT token
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["UserLogin"];
+                };
+            };
+            responses: {
+                /** @description Successful login */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Token"];
+                    };
+                };
+                /** @description Validation error */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                /** @description Invalid credentials */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/users": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get all users
+         * @description Retrieve a list of all users (root role required)
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description A list of users */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["UserInfo"][];
+                    };
+                };
+                /** @description Unauthorized */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                /** @description Forbidden - insufficient permissions */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        /**
+         * Create a new user
+         * @description Create a new user (root role required)
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["CreateUser"];
+                };
+            };
+            responses: {
+                /** @description User created successfully */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["UserInfo"];
+                    };
+                };
+                /** @description Validation error */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                /** @description Unauthorized */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                /** @description Forbidden - insufficient permissions */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/users/{userId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get a specific user
+         * @description Retrieve details of a specific user by ID (root role required)
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    userId: components["parameters"]["userId"];
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description User details */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["UserInfo"];
+                    };
+                };
+                /** @description Unauthorized */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                /** @description Forbidden - insufficient permissions */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                /** @description User not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/organisations": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Create a new organisation
+         * @description Create a new organisation with a root user
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["CreateOrganisation"];
+                };
+            };
+            responses: {
+                /** @description Organisation and root user created successfully */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            organisation?: components["schemas"]["Organisation"];
+                            user?: components["schemas"]["UserInfo"];
+                        };
+                    };
+                };
+                /** @description Validation error */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/instructions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get all instructions */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["InstructionInfoList"][];
+                    };
+                };
+                /** @description Validation error */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                /** @description Unauthorized */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                /** @description Forbidden - insufficient permissions */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        /** Create a new instruction */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["CreateInstruction"];
+                };
+            };
+            responses: {
+                /** @description The created instruction */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["InstructionDetails"];
+                    };
+                };
+                /** @description Validation error */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                /** @description Unauthorized */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                /** @description Forbidden - insufficient permissions */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/instructions/{instructionId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get an instruction */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    instructionId: components["parameters"]["instructionId"];
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Success */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["InstructionDetails"];
+                    };
+                };
+                /** @description Validation error */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                /** @description Unauthorized */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                /** @description Forbidden - insufficient permissions */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/instructions/{instructionId}/version/{versionId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get an instruction version */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    instructionId: components["parameters"]["instructionVersionId"];
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Success */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["InstructionVersion"];
+                    };
+                };
+                /** @description Validation error */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                /** @description Unauthorized */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                /** @description Forbidden - insufficient permissions */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+            };
+        };
+        /**
+         * Update an instruction version
+         * @description Update an instruction version.
+         */
+        put: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    instructionId: components["parameters"]["instructionVersionId"];
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            responses: {
+                /** @description Success */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["InstructionVersion"];
+                    };
+                };
+                /** @description Validation error */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                /** @description Unauthorized */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                /** @description Forbidden - insufficient permissions */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+            };
+        };
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
-	schemas: {
-		Token: {
-			/**
-			 * @description JWT token
-			 * @example eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
-			 */
-			token: string;
-		};
-		UserLogin: {
-			/**
-			 * Format: email
-			 * @description User email
-			 * @example johndoe@example.com
-			 */
-			email: string;
-			/**
-			 * Format: password
-			 * @description User password
-			 * @example password123
-			 */
-			password: string;
-		};
-		UserInfo: {
-			/** @example 5f8d0d55b547644294b9e7f8 */
-			id: string;
-			/** @example johndoe */
-			username: string;
-			/**
-			 * Format: email
-			 * @example johndoe@example.com
-			 */
-			email: string;
-			/** @example 5f8d0d55b547644294b9e7f9 */
-			organisationId: string;
-			/**
-			 * @example user
-			 * @enum {string}
-			 */
-			role: "root" | "admin" | "user";
-		};
-		CreateUser: {
-			/**
-			 * @description User username
-			 * @example johndoe
-			 */
-			username: string;
-			/**
-			 * Format: email
-			 * @description User email
-			 * @example johndoe@example.com
-			 */
-			email: string;
-			/**
-			 * @description User password
-			 * @example <PASSWORD>
-			 */
-			password: string;
-			/**
-			 * @description User role
-			 * @example admin
-			 */
-			role: string;
-		};
-		Organisation: {
-			/** @example 5f8d0d55b547644294b9e7f9 */
-			id: string;
-			/** @example Acme Corporation */
-			name: string;
-		};
-		CreateOrganisation: {
-			/**
-			 * @description Organisation name
-			 * @example Acme Corporation
-			 */
-			organisationName: string;
-			/**
-			 * @description User username
-			 * @example johndoe
-			 */
-			username: string;
-			/**
-			 * Format: email
-			 * @description User email
-			 * @example johndoe@example.com
-			 */
-			email: string;
-			/**
-			 * @description User password
-			 * @example <PASSWORD>
-			 */
-			password: string;
-		};
-		InstructionInfo: {
-			/**
-			 * Format: uuid
-			 * @example 5f8d0d55b547644294b9e7f8
-			 */
-			instructionId: string;
-			/**
-			 * @description Instruction name
-			 * @example My Instruction
-			 */
-			name: string;
-			/**
-			 * @description Instruction type
-			 * @enum {string}
-			 */
-			type: "personality" | "guardian" | "operation";
-		};
-		InstructionDetails: components["schemas"]["InstructionInfo"] & {
-			versions: components["schemas"]["InstructionVersionList"];
-		};
-		InstructionInfoList: components["schemas"]["InstructionInfo"][];
-		InstructionVersion: {
-			/**
-			 * @description Instruction version id
-			 * @example 1
-			 */
-			instructionVersionId: string;
-			/**
-			 * @description Instruction version
-			 * @example 1
-			 */
-			version: number;
-			/**
-			 * @description Instruction description
-			 * @example Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-			 */
-			description: string;
-			/**
-			 * @description Instruction content
-			 * @example Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-			 */
-			content: string;
-		};
-		InstructionVersionList: components["schemas"]["InstructionVersion"][];
-		CreateInstruction: {
-			/**
-			 * @description Instruction name
-			 * @example My Instruction
-			 */
-			name: string;
-			/**
-			 * @description Instruction content
-			 * @example Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-			 */
-			content: string;
-			/**
-			 * @description Instruction type
-			 * @enum {string}
-			 */
-			type: "personality" | "guardian" | "operation";
-			/**
-			 * @description Instruction description
-			 * @example Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-			 */
-			description?: string;
-		};
-		UpdateInstruction: {
-			/**
-			 * @description Instruction content
-			 * @example Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-			 */
-			content?: string;
-			/**
-			 * @description Instruction description
-			 * @example Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-			 */
-			description?: string;
-		};
-		Error: {
-			/** @example Error description */
-			message: string;
-			/** @example [
-			 *       "Field is required"
-			 *     ] */
-			errors?: string[];
-		};
-	};
-	responses: never;
-	parameters: {
-		userId: string;
-		instructionId: string;
-	};
-	requestBodies: never;
-	headers: never;
-	pathItems: never;
+    schemas: {
+        Token: {
+            /**
+             * @description JWT token
+             * @example eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+             */
+            token: string;
+        };
+        UserLogin: {
+            /**
+             * Format: email
+             * @description User email
+             * @example johndoe@example.com
+             */
+            email: string;
+            /**
+             * Format: password
+             * @description User password
+             * @example password123
+             */
+            password: string;
+        };
+        UserInfo: {
+            /** @example 5f8d0d55b547644294b9e7f8 */
+            id: string;
+            /** @example johndoe */
+            username: string;
+            /**
+             * Format: email
+             * @example johndoe@example.com
+             */
+            email: string;
+            /** @example 5f8d0d55b547644294b9e7f9 */
+            organisationId: string;
+            /**
+             * @example user
+             * @enum {string}
+             */
+            role: "root" | "admin" | "user";
+        };
+        CreateUser: {
+            /**
+             * @description User username
+             * @example johndoe
+             */
+            username: string;
+            /**
+             * Format: email
+             * @description User email
+             * @example johndoe@example.com
+             */
+            email: string;
+            /**
+             * @description User password
+             * @example <PASSWORD>
+             */
+            password: string;
+            /**
+             * @description User role
+             * @example admin
+             */
+            role: string;
+        };
+        Organisation: {
+            /** @example 5f8d0d55b547644294b9e7f9 */
+            id: string;
+            /** @example Acme Corporation */
+            name: string;
+        };
+        CreateOrganisation: {
+            /**
+             * @description Organisation name
+             * @example Acme Corporation
+             */
+            organisationName: string;
+            /**
+             * @description User username
+             * @example johndoe
+             */
+            username: string;
+            /**
+             * Format: email
+             * @description User email
+             * @example johndoe@example.com
+             */
+            email: string;
+            /**
+             * @description User password
+             * @example <PASSWORD>
+             */
+            password: string;
+        };
+        InstructionInfo: {
+            /**
+             * Format: uuid
+             * @example 5f8d0d55b547644294b9e7f8
+             */
+            instructionId: string;
+            /**
+             * @description Instruction name
+             * @example My Instruction
+             */
+            name: string;
+            /**
+             * @description Instruction type
+             * @enum {string}
+             */
+            type: "personality" | "guardian" | "operation";
+        };
+        InstructionDetails: components["schemas"]["InstructionInfo"] & {
+            versions: components["schemas"]["InstructionVersionList"];
+        };
+        InstructionInfoList: components["schemas"]["InstructionInfo"][];
+        InstructionVersion: {
+            /**
+             * @description Instruction version id
+             * @example 1
+             */
+            instructionVersionId: string;
+            /**
+             * @description Instruction version
+             * @example 1
+             */
+            version: number;
+            /**
+             * @description Instruction description
+             * @example Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+             */
+            description: string;
+            /**
+             * @description Instruction content
+             * @example Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+             */
+            content: string;
+        };
+        InstructionVersionList: components["schemas"]["InstructionVersion"][];
+        CreateInstruction: {
+            /**
+             * @description Instruction name
+             * @example My Instruction
+             */
+            name: string;
+            /**
+             * @description Instruction content
+             * @example Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+             */
+            content: string;
+            /**
+             * @description Instruction type
+             * @enum {string}
+             */
+            type: "personality" | "guardian" | "operation";
+            /**
+             * @description Instruction description
+             * @example Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+             */
+            description?: string;
+        };
+        UpdateInstruction: {
+            /**
+             * @description Instruction content
+             * @example Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+             */
+            content?: string;
+            /**
+             * @description Instruction description
+             * @example Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+             */
+            description?: string;
+        };
+        Error: {
+            /** @example Error description */
+            message: string;
+            /** @example [
+             *       "Field is required"
+             *     ] */
+            errors?: string[];
+        };
+    };
+    responses: never;
+    parameters: {
+        userId: string;
+        instructionId: string;
+        instructionVersionId: string;
+    };
+    requestBodies: never;
+    headers: never;
+    pathItems: never;
 }
 export type $defs = Record<string, never>;
 export type operations = Record<string, never>;

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -4,792 +4,792 @@
  */
 
 export interface paths {
-    "/auth/login": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * User login
-         * @description Authenticate a user and receive a JWT token
-         */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": components["schemas"]["UserLogin"];
-                };
-            };
-            responses: {
-                /** @description Successful login */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Token"];
-                    };
-                };
-                /** @description Validation error */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Invalid credentials */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/users": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get all users
-         * @description Retrieve a list of all users (root role required)
-         */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description A list of users */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["UserInfo"][];
-                    };
-                };
-                /** @description Unauthorized */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Forbidden - insufficient permissions */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
-        put?: never;
-        /**
-         * Create a new user
-         * @description Create a new user (root role required)
-         */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": components["schemas"]["CreateUser"];
-                };
-            };
-            responses: {
-                /** @description User created successfully */
-                201: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["UserInfo"];
-                    };
-                };
-                /** @description Validation error */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Unauthorized */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Forbidden - insufficient permissions */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/users/{userId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get a specific user
-         * @description Retrieve details of a specific user by ID (root role required)
-         */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    userId: components["parameters"]["userId"];
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description User details */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["UserInfo"];
-                    };
-                };
-                /** @description Unauthorized */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Forbidden - insufficient permissions */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description User not found */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/organisations": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Create a new organisation
-         * @description Create a new organisation with a root user
-         */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": components["schemas"]["CreateOrganisation"];
-                };
-            };
-            responses: {
-                /** @description Organisation and root user created successfully */
-                201: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            organisation?: components["schemas"]["Organisation"];
-                            user?: components["schemas"]["UserInfo"];
-                        };
-                    };
-                };
-                /** @description Validation error */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/instructions": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get all instructions */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description OK */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["InstructionInfoList"][];
-                    };
-                };
-                /** @description Validation error */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Unauthorized */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Forbidden - insufficient permissions */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
-        put?: never;
-        /** Create a new instruction */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": components["schemas"]["CreateInstruction"];
-                };
-            };
-            responses: {
-                /** @description The created instruction */
-                201: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["InstructionDetails"];
-                    };
-                };
-                /** @description Validation error */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Unauthorized */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Forbidden - insufficient permissions */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/instructions/{instructionId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get an instruction */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    instructionId: components["parameters"]["instructionId"];
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Success */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["InstructionDetails"];
-                    };
-                };
-                /** @description Validation error */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Unauthorized */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Forbidden - insufficient permissions */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/instructions/{instructionId}/version/{versionId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get an instruction version */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    instructionId: components["parameters"]["instructionVersionId"];
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Success */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["InstructionVersionInfo"];
-                    };
-                };
-                /** @description Validation error */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Unauthorized */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Forbidden - insufficient permissions */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
-        /**
-         * Update an instruction version
-         * @description Update an instruction version.
-         */
-        put: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    instructionId: components["parameters"]["instructionVersionId"];
-                };
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            responses: {
-                /** @description Success */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["InstructionVersionInfo"];
-                    };
-                };
-                /** @description Validation error */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Unauthorized */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Forbidden - insufficient permissions */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
+	"/auth/login": {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		get?: never;
+		put?: never;
+		/**
+		 * User login
+		 * @description Authenticate a user and receive a JWT token
+		 */
+		post: {
+			parameters: {
+				query?: never;
+				header?: never;
+				path?: never;
+				cookie?: never;
+			};
+			requestBody: {
+				content: {
+					"application/json": components["schemas"]["UserLogin"];
+				};
+			};
+			responses: {
+				/** @description Successful login */
+				200: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						"application/json": components["schemas"]["Token"];
+					};
+				};
+				/** @description Validation error */
+				400: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						"application/json": components["schemas"]["Error"];
+					};
+				};
+				/** @description Invalid credentials */
+				401: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						"application/json": components["schemas"]["Error"];
+					};
+				};
+			};
+		};
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
+	"/users": {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		/**
+		 * Get all users
+		 * @description Retrieve a list of all users (root role required)
+		 */
+		get: {
+			parameters: {
+				query?: never;
+				header?: never;
+				path?: never;
+				cookie?: never;
+			};
+			requestBody?: never;
+			responses: {
+				/** @description A list of users */
+				200: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						"application/json": components["schemas"]["UserInfo"][];
+					};
+				};
+				/** @description Unauthorized */
+				401: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						"application/json": components["schemas"]["Error"];
+					};
+				};
+				/** @description Forbidden - insufficient permissions */
+				403: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						"application/json": components["schemas"]["Error"];
+					};
+				};
+			};
+		};
+		put?: never;
+		/**
+		 * Create a new user
+		 * @description Create a new user (root role required)
+		 */
+		post: {
+			parameters: {
+				query?: never;
+				header?: never;
+				path?: never;
+				cookie?: never;
+			};
+			requestBody: {
+				content: {
+					"application/json": components["schemas"]["CreateUser"];
+				};
+			};
+			responses: {
+				/** @description User created successfully */
+				201: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						"application/json": components["schemas"]["UserInfo"];
+					};
+				};
+				/** @description Validation error */
+				400: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						"application/json": components["schemas"]["Error"];
+					};
+				};
+				/** @description Unauthorized */
+				401: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						"application/json": components["schemas"]["Error"];
+					};
+				};
+				/** @description Forbidden - insufficient permissions */
+				403: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						"application/json": components["schemas"]["Error"];
+					};
+				};
+			};
+		};
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
+	"/users/{userId}": {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		/**
+		 * Get a specific user
+		 * @description Retrieve details of a specific user by ID (root role required)
+		 */
+		get: {
+			parameters: {
+				query?: never;
+				header?: never;
+				path: {
+					userId: components["parameters"]["userId"];
+				};
+				cookie?: never;
+			};
+			requestBody?: never;
+			responses: {
+				/** @description User details */
+				200: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						"application/json": components["schemas"]["UserInfo"];
+					};
+				};
+				/** @description Unauthorized */
+				401: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						"application/json": components["schemas"]["Error"];
+					};
+				};
+				/** @description Forbidden - insufficient permissions */
+				403: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						"application/json": components["schemas"]["Error"];
+					};
+				};
+				/** @description User not found */
+				404: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						"application/json": components["schemas"]["Error"];
+					};
+				};
+			};
+		};
+		put?: never;
+		post?: never;
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
+	"/organisations": {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		get?: never;
+		put?: never;
+		/**
+		 * Create a new organisation
+		 * @description Create a new organisation with a root user
+		 */
+		post: {
+			parameters: {
+				query?: never;
+				header?: never;
+				path?: never;
+				cookie?: never;
+			};
+			requestBody: {
+				content: {
+					"application/json": components["schemas"]["CreateOrganisation"];
+				};
+			};
+			responses: {
+				/** @description Organisation and root user created successfully */
+				201: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						"application/json": {
+							organisation?: components["schemas"]["Organisation"];
+							user?: components["schemas"]["UserInfo"];
+						};
+					};
+				};
+				/** @description Validation error */
+				400: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						"application/json": components["schemas"]["Error"];
+					};
+				};
+			};
+		};
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
+	"/instructions": {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		/** Get all instructions */
+		get: {
+			parameters: {
+				query?: never;
+				header?: never;
+				path?: never;
+				cookie?: never;
+			};
+			requestBody?: never;
+			responses: {
+				/** @description OK */
+				200: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						"application/json": components["schemas"]["InstructionInfoList"][];
+					};
+				};
+				/** @description Validation error */
+				400: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						"application/json": components["schemas"]["Error"];
+					};
+				};
+				/** @description Unauthorized */
+				401: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						"application/json": components["schemas"]["Error"];
+					};
+				};
+				/** @description Forbidden - insufficient permissions */
+				403: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						"application/json": components["schemas"]["Error"];
+					};
+				};
+			};
+		};
+		put?: never;
+		/** Create a new instruction */
+		post: {
+			parameters: {
+				query?: never;
+				header?: never;
+				path?: never;
+				cookie?: never;
+			};
+			requestBody: {
+				content: {
+					"application/json": components["schemas"]["CreateInstruction"];
+				};
+			};
+			responses: {
+				/** @description The created instruction */
+				201: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						"application/json": components["schemas"]["InstructionDetails"];
+					};
+				};
+				/** @description Validation error */
+				400: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						"application/json": components["schemas"]["Error"];
+					};
+				};
+				/** @description Unauthorized */
+				401: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						"application/json": components["schemas"]["Error"];
+					};
+				};
+				/** @description Forbidden - insufficient permissions */
+				403: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						"application/json": components["schemas"]["Error"];
+					};
+				};
+			};
+		};
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
+	"/instructions/{instructionId}": {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		/** Get an instruction */
+		get: {
+			parameters: {
+				query?: never;
+				header?: never;
+				path: {
+					instructionId: components["parameters"]["instructionId"];
+				};
+				cookie?: never;
+			};
+			requestBody?: never;
+			responses: {
+				/** @description Success */
+				200: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						"application/json": components["schemas"]["InstructionDetails"];
+					};
+				};
+				/** @description Validation error */
+				400: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						"application/json": components["schemas"]["Error"];
+					};
+				};
+				/** @description Unauthorized */
+				401: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						"application/json": components["schemas"]["Error"];
+					};
+				};
+				/** @description Forbidden - insufficient permissions */
+				403: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						"application/json": components["schemas"]["Error"];
+					};
+				};
+			};
+		};
+		put?: never;
+		post?: never;
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
+	"/instructions/{instructionId}/version/{versionId}": {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		/** Get an instruction version */
+		get: {
+			parameters: {
+				query?: never;
+				header?: never;
+				path: {
+					instructionId: components["parameters"]["instructionVersionId"];
+				};
+				cookie?: never;
+			};
+			requestBody?: never;
+			responses: {
+				/** @description Success */
+				200: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						"application/json": components["schemas"]["InstructionVersionInfo"];
+					};
+				};
+				/** @description Validation error */
+				400: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						"application/json": components["schemas"]["Error"];
+					};
+				};
+				/** @description Unauthorized */
+				401: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						"application/json": components["schemas"]["Error"];
+					};
+				};
+				/** @description Forbidden - insufficient permissions */
+				403: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						"application/json": components["schemas"]["Error"];
+					};
+				};
+			};
+		};
+		/**
+		 * Update an instruction version
+		 * @description Update an instruction version.
+		 */
+		put: {
+			parameters: {
+				query?: never;
+				header?: never;
+				path: {
+					instructionId: components["parameters"]["instructionVersionId"];
+				};
+				cookie?: never;
+			};
+			requestBody: {
+				content: {
+					"application/json": unknown;
+				};
+			};
+			responses: {
+				/** @description Success */
+				200: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						"application/json": components["schemas"]["InstructionVersionInfo"];
+					};
+				};
+				/** @description Validation error */
+				400: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						"application/json": components["schemas"]["Error"];
+					};
+				};
+				/** @description Unauthorized */
+				401: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						"application/json": components["schemas"]["Error"];
+					};
+				};
+				/** @description Forbidden - insufficient permissions */
+				403: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						"application/json": components["schemas"]["Error"];
+					};
+				};
+			};
+		};
+		post?: never;
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
 }
 export type webhooks = Record<string, never>;
 export interface components {
-    schemas: {
-        Token: {
-            /**
-             * @description JWT token
-             * @example eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
-             */
-            token: string;
-        };
-        UserLogin: {
-            /**
-             * Format: email
-             * @description User email
-             * @example johndoe@example.com
-             */
-            email: string;
-            /**
-             * Format: password
-             * @description User password
-             * @example password123
-             */
-            password: string;
-        };
-        UserInfo: {
-            /** @example 5f8d0d55b547644294b9e7f8 */
-            id: string;
-            /** @example johndoe */
-            username: string;
-            /**
-             * Format: email
-             * @example johndoe@example.com
-             */
-            email: string;
-            /** @example 5f8d0d55b547644294b9e7f9 */
-            organisationId: string;
-            /**
-             * @example user
-             * @enum {string}
-             */
-            role: "root" | "admin" | "user";
-        };
-        CreateUser: {
-            /**
-             * @description User username
-             * @example johndoe
-             */
-            username: string;
-            /**
-             * Format: email
-             * @description User email
-             * @example johndoe@example.com
-             */
-            email: string;
-            /**
-             * @description User password
-             * @example <PASSWORD>
-             */
-            password: string;
-            /**
-             * @description User role
-             * @example admin
-             */
-            role: string;
-        };
-        Organisation: {
-            /** @example 5f8d0d55b547644294b9e7f9 */
-            id: string;
-            /** @example Acme Corporation */
-            name: string;
-        };
-        CreateOrganisation: {
-            /**
-             * @description Organisation name
-             * @example Acme Corporation
-             */
-            organisationName: string;
-            /**
-             * @description User username
-             * @example johndoe
-             */
-            username: string;
-            /**
-             * Format: email
-             * @description User email
-             * @example johndoe@example.com
-             */
-            email: string;
-            /**
-             * @description User password
-             * @example <PASSWORD>
-             */
-            password: string;
-        };
-        InstructionInfo: {
-            /**
-             * Format: uuid
-             * @example 5f8d0d55b547644294b9e7f8
-             */
-            instructionId: string;
-            /**
-             * @description Instruction name
-             * @example My Instruction
-             */
-            name: string;
-            /**
-             * @description Instruction type
-             * @enum {string}
-             */
-            type: "personality" | "guardian" | "operation";
-        };
-        InstructionDetails: components["schemas"]["InstructionInfo"] & {
-            versions: components["schemas"]["InstructionVersionInfoList"];
-        };
-        InstructionInfoList: components["schemas"]["InstructionInfo"][];
-        InstructionVersionInfo: {
-            /**
-             * @description Instruction version id
-             * @example 1
-             */
-            instructionVersionId: string;
-            /**
-             * @description Instruction version
-             * @example 1
-             */
-            version: number;
-            /**
-             * @description Instruction description
-             * @example Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-             */
-            description: string;
-            /**
-             * @description Instruction content
-             * @example Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-             */
-            content: string;
-        };
-        InstructionVersionInfoList: components["schemas"]["InstructionVersionInfo"][];
-        CreateInstruction: {
-            /**
-             * @description Instruction name
-             * @example My Instruction
-             */
-            name: string;
-            /**
-             * @description Instruction content
-             * @example Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-             */
-            content: string;
-            /**
-             * @description Instruction type
-             * @enum {string}
-             */
-            type: "personality" | "guardian" | "operation";
-            /**
-             * @description Instruction description
-             * @example Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-             */
-            description?: string;
-        };
-        UpdateInstruction: {
-            /**
-             * @description Instruction content
-             * @example Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-             */
-            content?: string;
-            /**
-             * @description Instruction description
-             * @example Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-             */
-            description?: string;
-        };
-        Error: {
-            /** @example Error description */
-            message: string;
-            /** @example [
-             *       "Field is required"
-             *     ] */
-            errors?: string[];
-        };
-    };
-    responses: never;
-    parameters: {
-        userId: string;
-        instructionId: string;
-        instructionVersionId: string;
-    };
-    requestBodies: never;
-    headers: never;
-    pathItems: never;
+	schemas: {
+		Token: {
+			/**
+			 * @description JWT token
+			 * @example eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+			 */
+			token: string;
+		};
+		UserLogin: {
+			/**
+			 * Format: email
+			 * @description User email
+			 * @example johndoe@example.com
+			 */
+			email: string;
+			/**
+			 * Format: password
+			 * @description User password
+			 * @example password123
+			 */
+			password: string;
+		};
+		UserInfo: {
+			/** @example 5f8d0d55b547644294b9e7f8 */
+			id: string;
+			/** @example johndoe */
+			username: string;
+			/**
+			 * Format: email
+			 * @example johndoe@example.com
+			 */
+			email: string;
+			/** @example 5f8d0d55b547644294b9e7f9 */
+			organisationId: string;
+			/**
+			 * @example user
+			 * @enum {string}
+			 */
+			role: "root" | "admin" | "user";
+		};
+		CreateUser: {
+			/**
+			 * @description User username
+			 * @example johndoe
+			 */
+			username: string;
+			/**
+			 * Format: email
+			 * @description User email
+			 * @example johndoe@example.com
+			 */
+			email: string;
+			/**
+			 * @description User password
+			 * @example <PASSWORD>
+			 */
+			password: string;
+			/**
+			 * @description User role
+			 * @example admin
+			 */
+			role: string;
+		};
+		Organisation: {
+			/** @example 5f8d0d55b547644294b9e7f9 */
+			id: string;
+			/** @example Acme Corporation */
+			name: string;
+		};
+		CreateOrganisation: {
+			/**
+			 * @description Organisation name
+			 * @example Acme Corporation
+			 */
+			organisationName: string;
+			/**
+			 * @description User username
+			 * @example johndoe
+			 */
+			username: string;
+			/**
+			 * Format: email
+			 * @description User email
+			 * @example johndoe@example.com
+			 */
+			email: string;
+			/**
+			 * @description User password
+			 * @example <PASSWORD>
+			 */
+			password: string;
+		};
+		InstructionInfo: {
+			/**
+			 * Format: uuid
+			 * @example 5f8d0d55b547644294b9e7f8
+			 */
+			instructionId: string;
+			/**
+			 * @description Instruction name
+			 * @example My Instruction
+			 */
+			name: string;
+			/**
+			 * @description Instruction type
+			 * @enum {string}
+			 */
+			type: "personality" | "guardian" | "operation";
+		};
+		InstructionDetails: components["schemas"]["InstructionInfo"] & {
+			versions: components["schemas"]["InstructionVersionInfoList"];
+		};
+		InstructionInfoList: components["schemas"]["InstructionInfo"][];
+		InstructionVersionInfo: {
+			/**
+			 * @description Instruction version id
+			 * @example 1
+			 */
+			instructionVersionId: string;
+			/**
+			 * @description Instruction version
+			 * @example 1
+			 */
+			version: number;
+			/**
+			 * @description Instruction description
+			 * @example Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+			 */
+			description: string;
+			/**
+			 * @description Instruction content
+			 * @example Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+			 */
+			content: string;
+		};
+		InstructionVersionInfoList: components["schemas"]["InstructionVersionInfo"][];
+		CreateInstruction: {
+			/**
+			 * @description Instruction name
+			 * @example My Instruction
+			 */
+			name: string;
+			/**
+			 * @description Instruction content
+			 * @example Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+			 */
+			content: string;
+			/**
+			 * @description Instruction type
+			 * @enum {string}
+			 */
+			type: "personality" | "guardian" | "operation";
+			/**
+			 * @description Instruction description
+			 * @example Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+			 */
+			description?: string;
+		};
+		UpdateInstruction: {
+			/**
+			 * @description Instruction content
+			 * @example Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+			 */
+			content?: string;
+			/**
+			 * @description Instruction description
+			 * @example Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+			 */
+			description?: string;
+		};
+		Error: {
+			/** @example Error description */
+			message: string;
+			/** @example [
+			 *       "Field is required"
+			 *     ] */
+			errors?: string[];
+		};
+	};
+	responses: never;
+	parameters: {
+		userId: string;
+		instructionId: string;
+		instructionVersionId: string;
+	};
+	requestBodies: never;
+	headers: never;
+	pathItems: never;
 }
 export type $defs = Record<string, never>;
 export type operations = Record<string, never>;

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -503,7 +503,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["InstructionVersion"];
+                        "application/json": components["schemas"]["InstructionVersionInfo"];
                     };
                 };
                 /** @description Validation error */
@@ -560,7 +560,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["InstructionVersion"];
+                        "application/json": components["schemas"]["InstructionVersionInfo"];
                     };
                 };
                 /** @description Validation error */
@@ -712,10 +712,10 @@ export interface components {
             type: "personality" | "guardian" | "operation";
         };
         InstructionDetails: components["schemas"]["InstructionInfo"] & {
-            versions: components["schemas"]["InstructionVersionList"];
+            versions: components["schemas"]["InstructionVersionInfoList"];
         };
         InstructionInfoList: components["schemas"]["InstructionInfo"][];
-        InstructionVersion: {
+        InstructionVersionInfo: {
             /**
              * @description Instruction version id
              * @example 1
@@ -737,7 +737,7 @@ export interface components {
              */
             content: string;
         };
-        InstructionVersionList: components["schemas"]["InstructionVersion"][];
+        InstructionVersionInfoList: components["schemas"]["InstructionVersionInfo"][];
         CreateInstruction: {
             /**
              * @description Instruction name

--- a/tests/instruction.test.js
+++ b/tests/instruction.test.js
@@ -161,4 +161,106 @@ describe("Instruction endpoints", () => {
 			expect(res.statusCode).toEqual(404);
 		});
 	});
+
+	describe("GET /api/instructions", () => {
+		let token, organisationId;
+
+		beforeEach(async () => {
+			const org = await new Organisation({ name: "Test Org" }).save();
+			organisationId = org._id.toString();
+
+			const salt = await bcrypt.genSalt(10);
+			const hashedPassword = await bcrypt.hash("password", salt);
+
+			const user = new User({
+				username: "testuser",
+				email: "testuser@test.com",
+				password: hashedPassword,
+				organisation_id: organisationId,
+				role: "user",
+			});
+			await user.save();
+
+			const resLogin = await request(app)
+				.post("/api/auth/login")
+				.send({ email: "testuser@test.com", password: "password" });
+			token = resLogin.body.token;
+
+			// We need an admin to create the instructions first
+			const adminUser = new User({
+				username: "adminuser",
+				email: "adminuser@test.com",
+				password: hashedPassword,
+				organisation_id: organisationId,
+				role: "admin",
+			});
+			await adminUser.save();
+			const resAdminLogin = await request(app)
+				.post("/api/auth/login")
+				.send({ email: "adminuser@test.com", password: "password" });
+			const adminToken = resAdminLogin.body.token;
+
+			const instruction1 = {
+				name: "Test Instruction 1",
+				content: "This is a test instruction 1.",
+				type: "personality",
+				description: "This is a test description 1.",
+			};
+			const instruction2 = {
+				name: "Test Instruction 2",
+				content: "This is a test instruction 2.",
+				type: "guardian",
+				description: "This is a test description 2.",
+			};
+
+			await request(app)
+				.post("/api/instructions")
+				.set("Authorization", `Bearer ${adminToken}`)
+				.send(instruction1);
+			await request(app)
+				.post("/api/instructions")
+				.set("Authorization", `Bearer ${adminToken}`)
+				.send(instruction2);
+		});
+
+		it("should return all instructions for the organisation", async () => {
+			const res = await request(app)
+				.get("/api/instructions")
+				.set("Authorization", `Bearer ${token}`);
+
+			expect(res.statusCode).toEqual(200);
+			expect(res.body.length).toBe(2);
+			expect(res.body[0].name).toBe("Test Instruction 1");
+			expect(res.body[1].name).toBe("Test Instruction 2");
+		});
+
+		it("should return an empty array if no instructions", async () => {
+			// Create another org and user with no instructions
+			const anotherOrg = await new Organisation({
+				name: "Another Org",
+			}).save();
+			const anotherOrganisationId = anotherOrg._id.toString();
+			const salt = await bcrypt.genSalt(10);
+			const hashedPassword = await bcrypt.hash("password", salt);
+			const anotherUser = new User({
+				username: "anotheruser",
+				email: "anotheruser@test.com",
+				password: hashedPassword,
+				organisation_id: anotherOrganisationId,
+				role: "user",
+			});
+			await anotherUser.save();
+			const resAnotherLogin = await request(app)
+				.post("/api/auth/login")
+				.send({ email: "anotheruser@test.com", password: "password" });
+			const anotherToken = resAnotherLogin.body.token;
+
+			const res = await request(app)
+				.get("/api/instructions")
+				.set("Authorization", `Bearer ${anotherToken}`);
+
+			expect(res.statusCode).toEqual(200);
+			expect(res.body.length).toBe(0);
+		});
+	});
 });


### PR DESCRIPTION
This commit implements the `GET /instructions` endpoint to retrieve all instructions for an organisation.

- Adds the `getAllInstructions` function to the instruction service to fetch instructions from the database.
- Adds the `getAllInstructions` controller function to handle the request and response.
- Adds the `GET /instructions` route, protected by authentication and user role.
- Adds the `toInstructionInfoList` mapper to format the response.
- Adds a new test suite for the `GET /instructions` endpoint to ensure it works as expected.